### PR TITLE
issue #20, add support for macro PROJECT_NAME

### DIFF
--- a/pipework/2. Usage.md
+++ b/pipework/2. Usage.md
@@ -132,7 +132,7 @@ If the container name contains any numeric components, then the last numeric com
 
 This variable is primarily useful for specifying some part of an ip address.
 
-#### @PROJECT_NAME@
+#### @COMPOSE_PROJECT_NAME@
 
 If the container is started by the `docker-compose` command, it is project name like set in `docker-compose --project-name `.
 

--- a/pipework/2. Usage.md
+++ b/pipework/2. Usage.md
@@ -5,7 +5,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
- 
+
 
 - [Supported Clients](#supported-clients)
   - [Command line usage (single invocation)](#command-line-usage-single-invocation)
@@ -131,6 +131,12 @@ The container's HOSTNAME. As set by `docker run --hostname=`.
 If the container name contains any numeric components, then the last numeric component in the container name. For example `prod_myapp_1` --> is determined to be instance number `1` of `prod_myapp`.
 
 This variable is primarily useful for specifying some part of an ip address.
+
+#### @PROJECT_NAME@
+
+If the container is started by the `docker-compose` command, it is project name like set in `docker-compose --project-name `.
+
+This variable is useful for differing the containter by the project. For example, you want to set different internal bridge for each project.
 
 <a name="known_errors"/>
 ### Known Errors

--- a/pipework/Dockerfile
+++ b/pipework/Dockerfile
@@ -31,4 +31,3 @@ RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--help"]
-

--- a/pipework/entrypoint.sh
+++ b/pipework/entrypoint.sh
@@ -133,6 +133,11 @@ _expand_macros ()
             instance="$(docker inspect -f {{.Name}} ${c12id} | grep -o -e '[0-9]*' | tail -1)"
             _pipework_vars="$(echo "$_pipework_vars" | sed -e "s|@INSTANCE@|${instance}|g")"
             ;;
+
+            @PROJECT_NAME@)
+            projectname="$(docker inspect   --format "{{ index .Config.Labels \"com.docker.compose.project\"}}" ${c12id})"
+            _pipework_vars="$(echo "$_pipework_vars" | sed -e "s|@PROJECT_NAME@|${projectname}|g")"
+            ;;
         esac
     done
 }
@@ -344,7 +349,7 @@ _process_container ()
         | grep -e 'pipework_cmd.*=\|^pipework_key=\|pipework_host_route.*='| sed -e 's/^/export "/g')"
     [ "$_pipework_vars" ] || return 0
 
-    _macros="$(echo -e "$_pipework_vars" | grep -o -e '@CONTAINER_NAME@\|@CONTAINER_ID@\|@HOSTNAME@\|@INSTANCE@' | sort | uniq)"
+    _macros="$(echo -e "$_pipework_vars" | grep -o -e '@CONTAINER_NAME@\|@CONTAINER_ID@\|@HOSTNAME@\|@INSTANCE@\|@PROJECT_NAME@' | sort | uniq)"
     [ "$_macros" ] && _expand_macros;
 
     eval $_pipework_vars

--- a/pipework/entrypoint.sh
+++ b/pipework/entrypoint.sh
@@ -134,9 +134,9 @@ _expand_macros ()
             _pipework_vars="$(echo "$_pipework_vars" | sed -e "s|@INSTANCE@|${instance}|g")"
             ;;
 
-            @PROJECT_NAME@)
+            @COMPOSE_PROJECT_NAME@)
             projectname="$(docker inspect   --format "{{ index .Config.Labels \"com.docker.compose.project\"}}" ${c12id})"
-            _pipework_vars="$(echo "$_pipework_vars" | sed -e "s|@PROJECT_NAME@|${projectname}|g")"
+            _pipework_vars="$(echo "$_pipework_vars" | sed -e "s|@COMPOSE_PROJECT_NAME@|${projectname}|g")"
             ;;
         esac
     done
@@ -349,7 +349,7 @@ _process_container ()
         | grep -e 'pipework_cmd.*=\|^pipework_key=\|pipework_host_route.*='| sed -e 's/^/export "/g')"
     [ "$_pipework_vars" ] || return 0
 
-    _macros="$(echo -e "$_pipework_vars" | grep -o -e '@CONTAINER_NAME@\|@CONTAINER_ID@\|@HOSTNAME@\|@INSTANCE@\|@PROJECT_NAME@' | sort | uniq)"
+    _macros="$(echo -e "$_pipework_vars" | grep -o -e '@CONTAINER_NAME@\|@CONTAINER_ID@\|@HOSTNAME@\|@INSTANCE@\|@COMPOSE_PROJECT_NAME@' | sort | uniq)"
     [ "$_macros" ] && _expand_macros;
 
     eval $_pipework_vars


### PR DESCRIPTION
it is used to differ project name in docker-compose environment
there exists .Config.Labels in docker inspect command

I verified under docker toolbox environment with different version
- docker-engine 1.10.3/docker-compose 1.6.2
- docker-engine 1.7.1/docker-compose 1.5.2
