### PR TITLE
Bump jackett to 0.7.1197

### DIFF
--- a/jackett/Dockerfile
+++ b/jackett/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -qqy cu
 
 
 # Download jackett
-ENV jackett_version="0.7.184"
+ENV jackett_version="0.7.1197"
 RUN curl -Lo /tmp/jackett.tar.gz https://github.com/Jackett/Jackett/releases/download/v${jackett_version}/Jackett.Binaries.Mono.tar.gz \
  && mkdir /jackett && tar -xzf /tmp/jackett.tar.gz --strip-components=1 -C /jackett && rm -f /tmp/jackett.tar.gz
 


### PR DESCRIPTION
I have a build with this version at https://dockerhub.com/r/underyx/jackett. I've updated and it's working just fine, however there are two warning popups, which say:

>It looks like the mono-devel package is not installed, please make sure it's installed to avoid crashes.

>mono version 4.2.* is known to cause problems with Jackett. If you experience any problems please try updating to the latest mono version from http://www.mono-project.com/download/ first.

I will not be updating the PR to get rid of these, so you might want to close it if you consider it a problem.